### PR TITLE
fix: correct import typo hoster → hosters in main_routes.py

### DIFF
--- a/kuasarr/api/captcha/main_routes.py
+++ b/kuasarr/api/captcha/main_routes.py
@@ -17,7 +17,7 @@ from kuasarr.providers.log import info
 from kuasarr.providers.ui.html_templates import render_button, render_centered_html, render_fail, render_success
 
 from .helpers import is_junkies_link, is_keeplinks_link, is_tolink_link, is_hide_link
-from kuasarr.providers.hoster import filter_blocked_hosters
+from kuasarr.providers.hosters import filter_blocked_hosters
 from kuasarr.downloads import fail
 
 


### PR DESCRIPTION
## Problem

Container crashes on startup:
```
ModuleNotFoundError: No module named 'kuasarr.providers.hoster'
```

## Root Cause

The CAPTCHA/hoster fix cherry-picked during migration introduced a typo: `hoster` (singular) instead of `hosters` (plural). The module is `kuasarr/providers/hosters.py`.

## Fix

```python
# before
from kuasarr.providers.hoster import filter_blocked_hosters
# after
from kuasarr.providers.hosters import filter_blocked_hosters
```

🤖 Generated with Claude Code