### PR TITLE
fix: correct import typo hoster → hosters in dbc_dispatcher.py

### DIFF
--- a/kuasarr/providers/captcha/dbc_dispatcher.py
+++ b/kuasarr/providers/captcha/dbc_dispatcher.py
@@ -40,7 +40,7 @@ from kuasarr.providers.captcha.dbc_client import (
 from kuasarr.providers.log import info, debug
 from kuasarr.providers.notifications import send_discord_message
 from kuasarr.providers.statistics import StatsHelper
-from kuasarr.providers.hoster import filter_blocked_hosters
+from kuasarr.providers.hosters import filter_blocked_hosters
 from kuasarr.downloads import fail
 from kuasarr.downloads.linkcrypters.filecrypt import CNL, DLC
 from kuasarr.downloads.linkcrypters.hide import unhide_links


### PR DESCRIPTION
## Problem

Container crashes on startup:
```
ModuleNotFoundError: No module named 'kuasarr.providers.hoster'
```

Same typo as PR #15, different file: `dbc_dispatcher.py`.

## Fix

```python
# before
from kuasarr.providers.hoster import filter_blocked_hosters
# after
from kuasarr.providers.hosters import filter_blocked_hosters
```

🤖 Generated with Claude Code