### PR TITLE
Add beta release pipeline for pull requests

### DIFF
--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -865,12 +865,41 @@ jobs:
             org.opencontainers.image.version=${{ needs.version-output.outputs.version }}
 
   # ═══════════════════════════════════════════════════════════════
+  # MERGE DOCKER MANIFEST (amd64 + arm64 → multi-arch)
+  # ═══════════════════════════════════════════════════════════════
+  merge-manifest:
+    name: Merge Docker Manifest
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    needs: [version-output, build-docker]
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge manifests
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.version-output.outputs.version }}"
+
+          docker buildx imagetools create \
+            -t ${{ env.GHCR_ENDPOINT }}:${VERSION} \
+            -t ${{ env.GHCR_ENDPOINT }}:latest \
+            ${{ env.GHCR_ENDPOINT }}:${VERSION}-amd64 \
+            ${{ env.GHCR_ENDPOINT }}:${VERSION}-arm64
+
+  # ═══════════════════════════════════════════════════════════════
   # AUTO TAG (create Git tag after successful builds)
   # ═══════════════════════════════════════════════════════════════
   auto-tag:
     name: Create Git Tag
     runs-on: ubuntu-latest
-    needs: [version-output, build-wheel, build-exe, build-docker]
+    needs: [version-output, build-wheel, build-exe, build-docker, merge-manifest]
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
@@ -913,7 +942,7 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [version-output, auto-tag, build-wheel, build-exe, build-docker]
+    needs: [version-output, auto-tag, build-wheel, build-exe, build-docker, merge-manifest]
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
@@ -973,7 +1002,7 @@ jobs:
   summary:
     name: CI Summary
     runs-on: ubuntu-latest
-    needs: [detect-changes, version-output, build-wheel, build-exe, build-docker, auto-tag, release, kimi-review, check-version, smoke-test, beta-version, beta-build-wheel, beta-build-exe, beta-build-docker-amd64, beta-build-docker-arm64, beta-merge-manifest, beta-release, beta-notify]
+    needs: [detect-changes, version-output, build-wheel, build-exe, build-docker, merge-manifest, auto-tag, release, kimi-review, check-version, smoke-test, beta-version, beta-build-wheel, beta-build-exe, beta-build-docker-amd64, beta-build-docker-arm64, beta-merge-manifest, beta-release, beta-notify]
     if: always()
     steps:
       - name: Generate Summary
@@ -1010,5 +1039,6 @@ jobs:
           echo "| Build Wheel | ${{ needs.build-wheel.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Build Windows EXE | ${{ needs.build-exe.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Build Docker (amd64+arm64) | ${{ needs.build-docker.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Merge Docker Manifest | ${{ needs.merge-manifest.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Auto Tag | ${{ needs.auto-tag.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Release & PyPI | ${{ needs.release.result }} |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
The PR introduces a comprehensive beta release pipeline that automatically builds
and publishes beta versions for all pull requests, plus a multi-arch Docker
manifest merge for production releases.

## Beta Pipeline (PR-only)

- **Beta Version Job**: Extracts version from `version.json` with semver validation,
  generates epoch timestamp
- **Beta Build Wheel**: Constructs Python wheel distribution with build provenance
  attestation
- **Beta Build Windows EXE**: Compiles Windows executable using PyInstaller with
  caching for faster builds
- **Beta Build Docker (amd64 & arm64)**: Native runners per architecture with
  GitHub Actions cache optimization
- **Beta Merge Docker Manifest**: Generates unified multi-arch manifest for `:beta`
  and `:{version}-beta` tags
- **Beta Release**: Forces `beta` git tag to current PR commit, creates/updates
  GitHub pre-release with artifacts and attestation link
- **Beta Notify PR**: Posts automated comment on PR with beta release details and
  download links

## Production Release (push to main)

- **Merge Docker Manifest**: After both arch builds complete, creates arch-agnostic tags:
  - `:latest` — always points to newest release
  - `:{version}` — pinned multi-arch tag
  - arch-specific tags (`:latest-amd64`, `:{version}-arm64` etc.) remain available
    for explicit pulls

## CI Summary

Enhanced summary report with separate PR/Beta and Release sections including
detailed status tables for all jobs.

All beta jobs are PR-only with proper `timeout-minutes` and job dependencies
ensuring correct build order and artifact availability.
