### PR TITLE
fix(ci): skip beta Docker push for Dependabot PRs

### DIFF
--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -509,7 +509,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [beta-version, beta-build-wheel]
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -551,7 +551,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     needs: [beta-version, beta-build-wheel]
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -593,7 +593,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     needs: [beta-version, beta-build-docker-amd64, beta-build-docker-arm64]
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     steps:
       - uses: docker/setup-buildx-action@v3
 
@@ -625,7 +625,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [beta-version, beta-build-wheel, beta-build-exe, beta-merge-manifest]
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Problem

Dependabot PRs fail on the beta Docker jobs:

```
denied: installation not allowed to Write organization package
```

GitHub grants Dependabot workflows `packages: read` only — pushing to GHCR is not permitted.

## Fix

Skip the four jobs that require GHCR write access for `dependabot[bot]`:

- `beta-build-docker-amd64`
- `beta-build-docker-arm64`
- `beta-merge-manifest`
- `beta-release`

Beta Wheel and Beta EXE jobs continue to run (no GHCR push, no issue).

## Test plan

- [ ] Trigger a Dependabot PR and verify the Docker jobs show as `skipped`
- [ ] Normal feature PR: beta Docker jobs still run as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)