### PR TITLE
Add GITHUB_TOKEN and improve beta version numbering with run counter

### DIFF
--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -381,6 +381,8 @@ jobs:
           fetch-depth: 0
 
       - id: version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -404,14 +406,26 @@ jobs:
             echo "ERROR: Invalid semver base: '$BASE_VERSION'" >&2; exit 1
           fi
 
-          # Increment patch by 1 and append -beta
+          # Increment patch by 1
           IFS=. read -r major minor patch <<< "$BASE_VERSION"
-          BETA_VERSION="${major}.${minor}.$((patch + 1))-beta"
+          NEXT_VERSION="${major}.${minor}.$((patch + 1))"
+
+          # Count workflow runs for this PR branch to get the beta run counter
+          BETA_COUNT=$(curl -s \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/unified-ci.yml/runs?branch=${{ github.head_ref }}&event=pull_request&per_page=1" \
+            | jq -r '.total_count // empty')
+          if ! [[ "${BETA_COUNT:-}" =~ ^[0-9]+$ ]] || [ "${BETA_COUNT:-0}" -lt 1 ]; then
+            BETA_COUNT=1
+          fi
+
+          BETA_VERSION="${NEXT_VERSION}-beta${BETA_COUNT}"
 
           EPOCH=$(date +%s)
           echo "version=$BETA_VERSION" >> $GITHUB_OUTPUT
           echo "epoch=$EPOCH" >> $GITHUB_OUTPUT
-          echo "Beta version: $BETA_VERSION (based on latest tag: ${latest_tag:-none})"
+          echo "Beta version: $BETA_VERSION (based on latest tag: ${latest_tag:-none}, run #${BETA_COUNT})"
 
   # ═══════════════════════════════════════════════════════════════
   # BETA BUILD WHEEL (PRs only)


### PR DESCRIPTION
## Summary
Enhanced the CI/CD pipeline's version generation step to use GitHub API for determining beta version numbers, providing more accurate and sequential versioning for pull request builds.

## Key Changes
- Added `GITHUB_TOKEN` environment variable to the version generation step to enable GitHub API calls
- Modified beta version naming scheme from simple `-beta` suffix to `-beta{N}` format where N is the workflow run counter
- Implemented GitHub API query to count existing workflow runs for the current PR branch
- Added fallback logic to default to run counter of 1 if API query fails or returns invalid data
- Updated logging output to display the run counter in version information

## Implementation Details
- Uses GitHub REST API (`/repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs`) to query workflow run counts filtered by branch and pull_request event
- Validates the API response using `jq` to extract `total_count` with fallback to empty string
- Includes error handling with regex validation to ensure the beta count is a valid positive integer
- The beta version format is now: `{major}.{minor}.{patch+1}-beta{run_count}` (e.g., `1.2.4-beta3`)

https://claude.ai/code/session_0178HGtP9iVB8LvBz7DZXVoG