### PR TITLE
Add API key authentication support to fetch requests

### DIFF
--- a/kuasarr/webui/src/lib/api.ts
+++ b/kuasarr/webui/src/lib/api.ts
@@ -23,13 +23,18 @@ import type {
 } from '../types';
 
 const API_BASE = '/api';
+const _API_KEY = typeof window !== 'undefined' ? window.KUASARR_API_KEY : undefined;
 
 async function fetchApi<T>(endpoint: string, options?: RequestInit): Promise<ApiResponse<T>> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(_API_KEY ? { 'X-API-Key': _API_KEY } : {}),
+    ...(options?.headers as Record<string, string> | undefined),
+  };
+
   const response = await fetch(`${API_BASE}${endpoint}`, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
     ...options,
+    headers,
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary
Added support for API key authentication in the web UI by reading the API key from the window object and including it in all API requests.

## Key Changes
- Read `KUASARR_API_KEY` from the global window object (when available in browser environment)
- Include the API key in request headers as `X-API-Key` when present
- Refactored header construction to properly merge default headers with optional user-provided headers and the API key header

## Implementation Details
- The API key is retrieved once at module load time and stored in `_API_KEY` constant
- Uses optional chaining to conditionally include the `X-API-Key` header only when an API key is available
- Maintains backward compatibility by making the API key optional - requests work with or without authentication
- Properly merges headers from multiple sources (defaults, API key, and user options) to avoid header conflicts