### PR TITLE
fix: UI display issues — API key, MIME types, response formats

### DIFF
--- a/kuasarr/api/__init__.py
+++ b/kuasarr/api/__init__.py
@@ -4,6 +4,9 @@
 
 import json
 import os
+import time as _time
+
+_APP_START = _time.time()
 
 from bottle import Bottle, static_file, request, response, abort
 
@@ -470,6 +473,23 @@ def get_api(shared_state_dict, shared_state_lock):
         </script>
         """
         return render_centered_html(info)
+
+    @app.get('/api/statistics')
+    @require_api_key
+    def get_statistics():
+        response.content_type = 'application/json'
+        return json.dumps({'data': {
+            'total_packages': 0,
+            'completed_packages': 0,
+            'failed_packages': 0,
+            'total_downloaded': 0,
+            'average_speed': 0,
+            'uptime_seconds': int(_time.time() - _APP_START),
+            'api_calls_today': 0,
+            'captchas_solved_today': 0,
+            'hoster_status': [],
+            'daily_stats': [],
+        }})
 
     @app.get('/api/jdownloader/status')
     @require_api_key

--- a/kuasarr/api/categories/__init__.py
+++ b/kuasarr/api/categories/__init__.py
@@ -4,7 +4,6 @@
 
 import json
 import re
-import html
 import time
 from typing import Optional
 
@@ -12,21 +11,10 @@ from bottle import request, response
 
 from kuasarr.providers import shared_state
 from kuasarr.providers.auth import require_api_key
-from kuasarr.providers.ui.html_templates import render_centered_html, render_button, render_nav
-from kuasarr.providers.ui.spa import try_serve_spa
-from kuasarr.storage.config import Config
 
 
 def setup_categories_routes(app):
     """Setup routes for category management."""
-
-    @app.get('/categories')
-    def categories_page():
-        """Render the category management UI."""
-        spa = try_serve_spa()
-        if spa is not None:
-            return spa
-        return _render_categories_page()
 
     @app.get('/api/categories')
     @require_api_key
@@ -34,7 +22,7 @@ def setup_categories_routes(app):
         """Get all categories as JSON."""
         response.content_type = 'application/json'
         categories = _get_all_categories()
-        return json.dumps({"success": True, "categories": categories})
+        return json.dumps({"data": categories})
 
     @app.get('/api/categories/<category_id>')
     @require_api_key
@@ -43,9 +31,9 @@ def setup_categories_routes(app):
         response.content_type = 'application/json'
         category = _get_category(category_id)
         if category:
-            return json.dumps({"success": True, "category": category})
+            return json.dumps({"data": category})
         response.status = 404
-        return json.dumps({"success": False, "error": "Category not found"})
+        return json.dumps({"error": {"message": "Category not found"}})
 
     @app.post('/api/categories')
     @require_api_key
@@ -55,24 +43,16 @@ def setup_categories_routes(app):
         try:
             data = request.json or {}
             name = data.get('name', '').strip()
-            download_path = data.get('download_path', '').strip()
-            file_patterns = data.get('file_patterns', [])
+            pattern = data.get('pattern', '').strip()
+            priority = int(data.get('priority', 0))
+            enabled = bool(data.get('enabled', True))
 
-            # Validation
             errors = {}
             if not name:
                 errors['name'] = 'Category name is required'
-            elif len(name) > 50:
-                errors['name'] = 'Category name must be 50 characters or less'
-            elif not re.match(r'^[a-zA-Z0-9_\-\s]+$', name):
-                errors['name'] = 'Category name can only contain letters, numbers, spaces, hyphens and underscores'
+            if not pattern:
+                errors['pattern'] = 'Pattern is required'
 
-            if not download_path:
-                errors['download_path'] = 'Download path is required'
-            elif len(download_path) > 500:
-                errors['download_path'] = 'Download path must be 500 characters or less'
-
-            # Check for duplicate name
             existing = _get_all_categories()
             for cat in existing:
                 if cat['name'].lower() == name.lower():
@@ -81,28 +61,23 @@ def setup_categories_routes(app):
 
             if errors:
                 response.status = 400
-                return json.dumps({"success": False, "errors": errors})
+                return json.dumps({"error": {"message": "Validation failed", "details": errors}})
 
-            # Generate ID from name
             category_id = _generate_category_id(name)
-
-            # Validate file patterns
-            validated_patterns = _validate_patterns(file_patterns)
-
             category = {
                 'id': category_id,
                 'name': name,
-                'download_path': download_path,
-                'file_patterns': validated_patterns,
-                'created_at': int(time.time())
+                'pattern': pattern,
+                'priority': priority,
+                'enabled': enabled,
+                'created_at': int(time.time()),
             }
-
             _save_category(category_id, category)
-            return json.dumps({"success": True, "category": category})
+            return json.dumps({"data": category})
 
         except Exception as e:
             response.status = 500
-            return json.dumps({"success": False, "error": str(e)})
+            return json.dumps({"error": {"message": str(e)}})
 
     @app.post('/api/categories/<category_id>')
     @require_api_key
@@ -113,28 +88,20 @@ def setup_categories_routes(app):
             existing = _get_category(category_id)
             if not existing:
                 response.status = 404
-                return json.dumps({"success": False, "error": "Category not found"})
+                return json.dumps({"error": {"message": "Category not found"}})
 
             data = request.json or {}
-            name = data.get('name', '').strip()
-            download_path = data.get('download_path', '').strip()
-            file_patterns = data.get('file_patterns', [])
+            name = data.get('name', existing.get('name', '')).strip()
+            pattern = data.get('pattern', existing.get('pattern', '')).strip()
+            priority = int(data.get('priority', existing.get('priority', 0)))
+            enabled = bool(data.get('enabled', existing.get('enabled', True)))
 
-            # Validation
             errors = {}
             if not name:
                 errors['name'] = 'Category name is required'
-            elif len(name) > 50:
-                errors['name'] = 'Category name must be 50 characters or less'
-            elif not re.match(r'^[a-zA-Z0-9_\-\s]+$', name):
-                errors['name'] = 'Category name can only contain letters, numbers, spaces, hyphens and underscores'
+            if not pattern:
+                errors['pattern'] = 'Pattern is required'
 
-            if not download_path:
-                errors['download_path'] = 'Download path is required'
-            elif len(download_path) > 500:
-                errors['download_path'] = 'Download path must be 500 characters or less'
-
-            # Check for duplicate name (excluding current category)
             all_categories = _get_all_categories()
             for cat in all_categories:
                 if cat['id'] != category_id and cat['name'].lower() == name.lower():
@@ -143,21 +110,18 @@ def setup_categories_routes(app):
 
             if errors:
                 response.status = 400
-                return json.dumps({"success": False, "errors": errors})
-
-            # Validate file patterns
-            validated_patterns = _validate_patterns(file_patterns)
+                return json.dumps({"error": {"message": "Validation failed", "details": errors}})
 
             category = {
                 'id': category_id,
                 'name': name,
-                'download_path': download_path,
-                'file_patterns': validated_patterns,
-                'created_at': existing.get('created_at', 0)
+                'pattern': pattern,
+                'priority': priority,
+                'enabled': enabled,
+                'created_at': existing.get('created_at', 0),
             }
-
             _save_category(category_id, category)
-            return json.dumps({"success": True, "category": category})
+            return json.dumps({"data": category})
 
         except Exception as e:
             response.status = 500
@@ -200,20 +164,17 @@ def _generate_category_id(name: str) -> str:
     return category_id
 
 
-def _validate_patterns(patterns) -> list:
-    """Validate and clean file patterns."""
-    if not patterns:
-        return []
 
-    validated = []
-    for pattern in patterns:
-        if isinstance(pattern, str):
-            pattern = pattern.strip()
-            if pattern and len(pattern) <= 100:
-                # Basic pattern validation - allow glob-style patterns
-                if re.match(r'^[a-zA-Z0-9_\-\*\.\?\[\]]+$', pattern):
-                    validated.append(pattern)
-    return validated
+def _normalise_category(category: dict) -> dict:
+    """Ensure category has the fields expected by the React UI."""
+    if 'pattern' not in category:
+        # Migrate old-format record: download_path + file_patterns → pattern
+        category = dict(category)
+        category['pattern'] = category.pop('download_path', '')
+        category.pop('file_patterns', None)
+    category.setdefault('priority', 0)
+    category.setdefault('enabled', True)
+    return category
 
 
 def _get_all_categories() -> list:
@@ -224,7 +185,7 @@ def _get_all_categories() -> list:
         categories = []
         for key, value in raw_data:
             try:
-                category = json.loads(value)
+                category = _normalise_category(json.loads(value))
                 categories.append(category)
             except json.JSONDecodeError:
                 continue
@@ -239,7 +200,7 @@ def _get_category(category_id: str) -> Optional[dict]:
         db = shared_state.get_db("categories")
         value = db.retrieve(category_id)
         if value:
-            return json.loads(value)
+            return _normalise_category(json.loads(value))
         return None
     except Exception:
         return None
@@ -256,590 +217,3 @@ def _delete_category(category_id: str):
     db = shared_state.get_db("categories")
     db.delete(category_id)
 
-
-def _render_categories_page():
-    """Render the categories management page."""
-    nav = render_nav('/categories')
-
-    html_content = f'''
-    <h1><img src="/static/logo.png" alt="kuasarr logo" class="logo"/>kuasarr</h1>
-    {nav}
-    <h2>Category Management</h2>
-    <p>Organize downloads into categories with custom download paths and file patterns.</p>
-
-    <div class="categories-actions">
-        <button class="btn-primary" onclick="showAddCategoryModal()">
-            <span class="btn-icon">+</span> Add Category
-        </button>
-    </div>
-
-    <div id="categories-list" class="categories-list">
-        <div class="loading-message">Loading categories...</div>
-    </div>
-
-    <div id="category-form-modal" class="modal-overlay">
-        <div class="modal">
-            <h3 id="modal-title">Add Category</h3>
-            <form id="category-form">
-                <input type="hidden" id="category-id" value="">
-
-                <div class="form-group">
-                    <label for="category-name">Category Name <span class="required">*</span></label>
-                    <input type="text" id="category-name" name="name" maxlength="50" required
-                           placeholder="e.g., Movies, TV Shows, Music">
-                    <div class="field-error" id="name-error"></div>
-                </div>
-
-                <div class="form-group">
-                    <label for="category-path">Download Path <span class="required">*</span></label>
-                    <input type="text" id="category-path" name="download_path" maxlength="500" required
-                           placeholder="/downloads/movies">
-                    <div class="form-help">Absolute path where downloads in this category will be saved</div>
-                    <div class="field-error" id="path-error"></div>
-                </div>
-
-                <div class="form-group">
-                    <label for="category-patterns">File Patterns</label>
-                    <div class="patterns-container" id="patterns-container">
-                        <div class="pattern-row">
-                            <input type="text" class="pattern-input" placeholder="*.mkv" maxlength="100">
-                            <button type="button" class="btn-icon-remove" onclick="removePatternRow(this)">-</button>
-                        </div>
-                    </div>
-                    <button type="button" class="btn-secondary btn-sm" onclick="addPatternRow()">+ Add Pattern</button>
-                    <div class="form-help">File patterns to auto-assign to this category (e.g., *.mkv, *movie*)</div>
-                </div>
-
-                <div class="form-feedback" id="form-feedback"></div>
-
-                <div class="modal-actions">
-                    <button type="button" class="btn-secondary" onclick="closeCategoryModal()">Cancel</button>
-                    <button type="submit" class="btn-primary">
-                        <span class="btn-text">Save</span>
-                        <span class="btn-spinner" hidden>Saving...</span>
-                    </button>
-                </div>
-            </form>
-        </div>
-    </div>
-
-    <div id="delete-modal" class="modal-overlay">
-        <div class="modal modal-small">
-            <h3>Delete Category?</h3>
-            <p>Are you sure you want to delete the category <strong id="delete-category-name"></strong>?</p>
-            <p class="warning-text">This action cannot be undone.</p>
-            <div class="modal-actions">
-                <button type="button" class="btn-secondary" onclick="closeDeleteModal()">Cancel</button>
-                <button type="button" class="btn-danger" id="confirm-delete-btn">Delete</button>
-            </div>
-        </div>
-    </div>
-
-    <style>
-        .categories-actions {{
-            margin: 20px 0;
-            text-align: left;
-        }}
-
-        .categories-list {{
-            display: flex;
-            flex-direction: column;
-            gap: 12px;
-            max-width: 700px;
-            margin: 0 auto;
-        }}
-
-        .category-card {{
-            background: var(--card-bg);
-            border: 1px solid var(--card-border);
-            border-radius: var(--border-radius);
-            padding: 16px;
-            text-align: left;
-            transition: box-shadow 0.2s ease;
-        }}
-
-        .category-card:hover {{
-            box-shadow: 0 2px 8px var(--card-shadow);
-        }}
-
-        .category-header {{
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 8px;
-        }}
-
-        .category-name {{
-            font-size: 1.1rem;
-            font-weight: 600;
-            color: var(--fg-color);
-        }}
-
-        .category-path {{
-            font-family: monospace;
-            font-size: 0.9rem;
-            color: var(--text-muted);
-            margin-bottom: 8px;
-            word-break: break-all;
-        }}
-
-        .category-patterns {{
-            display: flex;
-            flex-wrap: wrap;
-            gap: 6px;
-            margin-top: 8px;
-        }}
-
-        .pattern-tag {{
-            background: var(--code-bg);
-            padding: 2px 8px;
-            border-radius: 4px;
-            font-size: 0.85rem;
-            font-family: monospace;
-            color: var(--fg-color);
-        }}
-
-        .category-actions {{
-            display: flex;
-            gap: 8px;
-        }}
-
-        .btn-small {{
-            padding: 4px 12px;
-            font-size: 0.85rem;
-        }}
-
-        .empty-message {{
-            text-align: center;
-            padding: 40px 20px;
-            color: var(--text-muted);
-        }}
-
-        .loading-message {{
-            text-align: center;
-            padding: 40px 20px;
-            color: var(--text-muted);
-        }}
-
-        /* Modal styles */
-        .modal-overlay {{
-            position: fixed;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            background: rgba(0, 0, 0, 0.5);
-            display: none;
-            justify-content: center;
-            align-items: flex-start;
-            z-index: 1000;
-            padding: 20px;
-            overflow-y: auto;
-        }}
-
-        .modal-overlay.active {{
-            display: flex;
-        }}
-
-        .modal {{
-            background: var(--card-bg);
-            border-radius: var(--border-radius);
-            padding: 24px;
-            max-width: 500px;
-            width: 100%;
-            margin: auto;
-            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
-        }}
-
-        .modal-small {{
-            max-width: 400px;
-        }}
-
-        .modal h3 {{
-            margin-top: 0;
-            margin-bottom: 20px;
-        }}
-
-        .modal-actions {{
-            display: flex;
-            justify-content: flex-end;
-            gap: 12px;
-            margin-top: 24px;
-        }}
-
-        .form-group {{
-            margin-bottom: 16px;
-            text-align: left;
-        }}
-
-        .form-group label {{
-            display: block;
-            font-weight: 500;
-            margin-bottom: 6px;
-        }}
-
-        .required {{
-            color: var(--error-color);
-        }}
-
-        .form-help {{
-            font-size: 0.85rem;
-            color: var(--text-muted);
-            margin-top: 4px;
-        }}
-
-        .field-error {{
-            display: none;
-            color: var(--error-color);
-            font-size: 0.85rem;
-            margin-top: 4px;
-        }}
-
-        .field-error.visible {{
-            display: block;
-        }}
-
-        .patterns-container {{
-            margin-bottom: 8px;
-        }}
-
-        .pattern-row {{
-            display: flex;
-            gap: 8px;
-            margin-bottom: 8px;
-        }}
-
-        .pattern-row input {{
-            flex: 1;
-            margin-bottom: 0;
-        }}
-
-        .btn-icon-remove {{
-            background: var(--error-color);
-            color: white;
-            border: none;
-            width: 32px;
-            height: 32px;
-            border-radius: 4px;
-            cursor: pointer;
-            font-size: 1.2rem;
-            line-height: 1;
-        }}
-
-        .btn-icon-remove:hover {{
-            opacity: 0.9;
-        }}
-
-        .warning-text {{
-            color: var(--error-color);
-            font-size: 0.9rem;
-        }}
-
-        .btn-icon {{
-            margin-right: 4px;
-        }}
-
-        @media (max-width: 600px) {{
-            .modal {{
-                margin: 0;
-                max-height: 90vh;
-                overflow-y: auto;
-            }}
-
-            .category-header {{
-                flex-direction: column;
-                align-items: flex-start;
-                gap: 8px;
-            }}
-
-            .modal-actions {{
-                flex-direction: column-reverse;
-            }}
-
-            .modal-actions button {{
-                width: 100%;
-            }}
-        }}
-    </style>
-
-    <script>
-        let categories = [];
-        let deleteCategoryId = null;
-
-        // Load categories on page load
-        document.addEventListener('DOMContentLoaded', loadCategories);
-
-        async function loadCategories() {{
-            try {{
-                const response = await kuasarrApiFetch('/api/categories');
-                const data = await response.json();
-
-                if (data.success) {{
-                    categories = data.categories || [];
-                    renderCategories();
-                }} else {{
-                    showError('Failed to load categories: ' + (data.error || 'Unknown error'));
-                }}
-            }} catch (e) {{
-                showError('Failed to load categories: ' + e.message);
-            }}
-        }}
-
-        function renderCategories() {{
-            const container = document.getElementById('categories-list');
-
-            if (categories.length === 0) {{
-                container.innerHTML = `
-                    <div class="empty-message">
-                        <p>No categories yet.</p>
-                        <p>Click "Add Category" to create your first category.</p>
-                    </div>
-                `;
-                return;
-            }}
-
-            container.innerHTML = categories.map(cat => `
-                <div class="category-card" data-id="${{cat.id}}">
-                    <div class="category-header">
-                        <span class="category-name">${{escapeHtml(cat.name)}}</span>
-                        <div class="category-actions">
-                            <button class="btn-secondary btn-sm" onclick="editCategory('${{cat.id}}')">Edit</button>
-                            <button class="btn-danger btn-sm" onclick="confirmDeleteCategory('${{cat.id}}')">Delete</button>
-                        </div>
-                    </div>
-                    <div class="category-path">${{escapeHtml(cat.download_path)}}</div>
-                    ${{cat.file_patterns && cat.file_patterns.length > 0 ? `
-                        <div class="category-patterns">
-                            ${{cat.file_patterns.map(p => `<span class="pattern-tag">${{escapeHtml(p)}}</span>`).join('')}}
-                        </div>
-                    ` : ''}}
-                </div>
-            `).join('');
-        }}
-
-        function escapeHtml(text) {{
-            const div = document.createElement('div');
-            div.textContent = text;
-            return div.innerHTML;
-        }}
-
-        function showAddCategoryModal() {{
-            document.getElementById('modal-title').textContent = 'Add Category';
-            document.getElementById('category-id').value = '';
-            document.getElementById('category-form').reset();
-            document.getElementById('patterns-container').innerHTML = `
-                <div class="pattern-row">
-                    <input type="text" class="pattern-input" placeholder="*.mkv" maxlength="100">
-                    <button type="button" class="btn-icon-remove" onclick="removePatternRow(this)">-</button>
-                </div>
-            `;
-            clearErrors();
-            document.getElementById('category-form-modal').classList.add('active');
-        }}
-
-        function editCategory(categoryId) {{
-            const category = categories.find(c => c.id === categoryId);
-            if (!category) return;
-
-            document.getElementById('modal-title').textContent = 'Edit Category';
-            document.getElementById('category-id').value = category.id;
-            document.getElementById('category-name').value = category.name;
-            document.getElementById('category-path').value = category.download_path;
-
-            // Render patterns
-            const patterns = category.file_patterns || [];
-            const container = document.getElementById('patterns-container');
-            if (patterns.length > 0) {{
-                container.innerHTML = patterns.map(p => `
-                    <div class="pattern-row">
-                        <input type="text" class="pattern-input" value="${{escapeHtml(p)}}" maxlength="100">
-                        <button type="button" class="btn-icon-remove" onclick="removePatternRow(this)">-</button>
-                    </div>
-                `).join('');
-            }} else {{
-                container.innerHTML = `
-                    <div class="pattern-row">
-                        <input type="text" class="pattern-input" placeholder="*.mkv" maxlength="100">
-                        <button type="button" class="btn-icon-remove" onclick="removePatternRow(this)">-</button>
-                    </div>
-                `;
-            }}
-
-            clearErrors();
-            document.getElementById('category-form-modal').classList.add('active');
-        }}
-
-        function closeCategoryModal() {{
-            document.getElementById('category-form-modal').classList.remove('active');
-        }}
-
-        function addPatternRow() {{
-            const container = document.getElementById('patterns-container');
-            const row = document.createElement('div');
-            row.className = 'pattern-row';
-            row.innerHTML = `
-                <input type="text" class="pattern-input" placeholder="*.mp4" maxlength="100">
-                <button type="button" class="btn-icon-remove" onclick="removePatternRow(this)">-</button>
-            `;
-            container.appendChild(row);
-        }}
-
-        function removePatternRow(btn) {{
-            const rows = document.querySelectorAll('.pattern-row');
-            if (rows.length > 1) {{
-                btn.closest('.pattern-row').remove();
-            }} else {{
-                // Clear the input instead of removing the last row
-                const input = btn.closest('.pattern-row').querySelector('input');
-                input.value = '';
-            }}
-        }}
-
-        function clearErrors() {{
-            document.querySelectorAll('.field-error').forEach(el => el.classList.remove('visible'));
-            document.querySelectorAll('.form-group input').forEach(el => el.classList.remove('has-error'));
-            document.getElementById('form-feedback').textContent = '';
-            document.getElementById('form-feedback').className = 'form-feedback';
-        }}
-
-        function showFieldError(fieldId, message) {{
-            const errorEl = document.getElementById(fieldId + '-error');
-            const inputEl = document.getElementById('category-' + fieldId.replace('_', '-'));
-            if (errorEl) {{
-                errorEl.textContent = message;
-                errorEl.classList.add('visible');
-            }}
-            if (inputEl) {{
-                inputEl.classList.add('has-error');
-            }}
-        }}
-
-        function showFormFeedback(message, isError) {{
-            const feedback = document.getElementById('form-feedback');
-            feedback.textContent = message;
-            feedback.className = 'form-feedback ' + (isError ? 'error' : 'success');
-        }}
-
-        function showError(message) {{
-            const container = document.getElementById('categories-list');
-            container.innerHTML = `<div class="empty-message" style="color: var(--error-color);">${{escapeHtml(message)}}</div>`;
-        }}
-
-        // Form submission
-        document.getElementById('category-form').addEventListener('submit', async function(e) {{
-            e.preventDefault();
-            clearErrors();
-
-            const categoryId = document.getElementById('category-id').value;
-            const name = document.getElementById('category-name').value.trim();
-            const downloadPath = document.getElementById('category-path').value.trim();
-
-            // Collect patterns
-            const patterns = [];
-            document.querySelectorAll('.pattern-input').forEach(input => {{
-                const value = input.value.trim();
-                if (value) patterns.push(value);
-            }});
-
-            const data = {{
-                name: name,
-                download_path: downloadPath,
-                file_patterns: patterns
-            }};
-
-            const submitBtn = this.querySelector('button[type="submit"]');
-            const btnText = submitBtn.querySelector('.btn-text');
-            const btnSpinner = submitBtn.querySelector('.btn-spinner');
-
-            submitBtn.disabled = true;
-            btnText.hidden = true;
-            btnSpinner.hidden = false;
-
-            try {{
-                const url = categoryId ? `/api/categories/${{categoryId}}` : '/api/categories';
-                const method = categoryId ? 'POST' : 'POST';
-
-                const response = await kuasarrApiFetch(url, {{
-                    method: method,
-                    headers: {{'Content-Type': 'application/json'}},
-                    body: JSON.stringify(data)
-                }});
-
-                const result = await response.json();
-
-                if (result.success) {{
-                    closeCategoryModal();
-                    await loadCategories();
-                }} else if (result.errors) {{
-                    Object.keys(result.errors).forEach(field => {{
-                        showFieldError(field, result.errors[field]);
-                    }});
-                    showFormFeedback('Please correct the errors above.', true);
-                }} else {{
-                    showFormFeedback(result.error || 'An error occurred.', true);
-                }}
-            }} catch (e) {{
-                showFormFeedback('Network error: ' + e.message, true);
-            }} finally {{
-                submitBtn.disabled = false;
-                btnText.hidden = false;
-                btnSpinner.hidden = true;
-            }}
-        }});
-
-        // Delete functionality
-        function confirmDeleteCategory(categoryId) {{
-            const category = categories.find(c => c.id === categoryId);
-            if (!category) return;
-
-            deleteCategoryId = categoryId;
-            document.getElementById('delete-category-name').textContent = category.name;
-            document.getElementById('delete-modal').classList.add('active');
-        }}
-
-        function closeDeleteModal() {{
-            document.getElementById('delete-modal').classList.remove('active');
-            deleteCategoryId = null;
-        }}
-
-        document.getElementById('confirm-delete-btn').addEventListener('click', async function() {{
-            if (!deleteCategoryId) return;
-
-            try {{
-                const response = await kuasarrApiFetch(`/api/categories/${{deleteCategoryId}}`, {{
-                    method: 'DELETE'
-                }});
-
-                const result = await response.json();
-
-                if (result.success) {{
-                    closeDeleteModal();
-                    await loadCategories();
-                }} else {{
-                    alert('Failed to delete: ' + (result.error || 'Unknown error'));
-                }}
-            }} catch (e) {{
-                alert('Network error: ' + e.message);
-            }}
-        }});
-
-        // Close modals on overlay click
-        document.getElementById('category-form-modal').addEventListener('click', function(e) {{
-            if (e.target === this) closeCategoryModal();
-        }});
-
-        document.getElementById('delete-modal').addEventListener('click', function(e) {{
-            if (e.target === this) closeDeleteModal();
-        }});
-
-        // Close modals on Escape key
-        document.addEventListener('keydown', function(e) {{
-            if (e.key === 'Escape') {{
-                closeCategoryModal();
-                closeDeleteModal();
-            }}
-        }});
-    </script>
-    '''
-
-    return render_centered_html(html_content)

--- a/kuasarr/api/hosters/__init__.py
+++ b/kuasarr/api/hosters/__init__.py
@@ -9,177 +9,11 @@ from bottle import request, response
 from kuasarr.providers import shared_state
 from kuasarr.providers.auth import require_api_key
 from kuasarr.providers.hosters import SUPPORTED_HOSTERS
-from kuasarr.providers.ui.html_templates import render_centered_html, render_button
-from kuasarr.providers.ui.spa import try_serve_spa
 from kuasarr.storage.config import Config
 
 
 def setup_hosters_routes(app):
     """Setup routes for hoster management."""
-
-    @app.get('/hosters')
-    def hosters_page():
-        """Render the hoster blocking UI."""
-        spa = try_serve_spa()
-        if spa is not None:
-            return spa
-        blocked = _get_blocked_list()
-        
-        hoster_cards = ""
-        for hoster_id, hoster_info in sorted(SUPPORTED_HOSTERS.items(), key=lambda x: x[1]["name"]):
-            is_blocked = hoster_id in blocked
-            status_class = "blocked" if is_blocked else "allowed"
-            status_text = "Blocked" if is_blocked else "Allowed"
-            button_text = "Unblock" if is_blocked else "Block"
-            button_class = "btn-primary" if is_blocked else "btn-danger"
-            
-            hoster_cards += f"""
-            <div class="hoster-card {status_class}" data-hoster="{hoster_id}">
-                <div class="hoster-info">
-                    <span class="hoster-name">{hoster_info['name']}</span>
-                    <span class="hoster-domain">{hoster_info['domain']}</span>
-                </div>
-                <div class="hoster-status">
-                    <span class="status-badge {status_class}">{status_text}</span>
-                    <button class="{button_class} small toggle-btn" 
-                            onclick="toggleHoster('{hoster_id}', {str(is_blocked).lower()})">
-                        {button_text}
-                    </button>
-                </div>
-            </div>
-            """
-        
-        html = f"""
-        <h1>File Hoster Management</h1>
-        <p>Block specific file hosters to prevent downloads from them.</p>
-        
-        <div class="hoster-actions">
-            <button class="btn-secondary" onclick="blockAll()">Block All</button>
-            <button class="btn-secondary" onclick="unblockAll()">Unblock All</button>
-        </div>
-        
-        <div class="hoster-list">
-            {hoster_cards}
-        </div>
-        
-        <p style="margin-top: 20px;">
-            {render_button("Back to Home", "secondary", {"onclick": "location.href='/'"})}
-        </p>
-        
-        <style>
-            .hoster-actions {{
-                margin: 20px 0;
-                display: flex;
-                gap: 10px;
-            }}
-            .hoster-list {{
-                display: flex;
-                flex-direction: column;
-                gap: 10px;
-                max-width: 600px;
-            }}
-            .hoster-card {{
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
-                padding: 15px;
-                border-radius: 8px;
-                background: #f8f9fa;
-                border: 1px solid #dee2e6;
-            }}
-            .hoster-card.blocked {{
-                background: #fff5f5;
-                border-color: #f5c6cb;
-            }}
-            .hoster-card.allowed {{
-                background: #f0fff4;
-                border-color: #c3e6cb;
-            }}
-            .hoster-info {{
-                display: flex;
-                flex-direction: column;
-            }}
-            .hoster-name {{
-                font-weight: 600;
-                font-size: 1.1em;
-            }}
-            .hoster-domain {{
-                color: #6c757d;
-                font-size: 0.9em;
-            }}
-            .hoster-status {{
-                display: flex;
-                align-items: center;
-                gap: 10px;
-            }}
-            .status-badge {{
-                padding: 4px 12px;
-                border-radius: 12px;
-                font-size: 0.85em;
-                font-weight: 500;
-            }}
-            .status-badge.blocked {{
-                background: #dc3545;
-                color: white;
-            }}
-            .status-badge.allowed {{
-                background: #28a745;
-                color: white;
-            }}
-            .btn-danger {{
-                background: #dc3545;
-                color: white;
-                border: none;
-                padding: 6px 12px;
-                border-radius: 4px;
-                cursor: pointer;
-            }}
-            .btn-danger:hover {{
-                background: #c82333;
-            }}
-        </style>
-        
-        <script>
-            async function toggleHoster(hosterId, currentlyBlocked) {{
-                const action = currentlyBlocked ? 'unblock' : 'block';
-                try {{
-                    const response = await kuasarrApiFetch('/api/hosters/' + action, {{
-                        method: 'POST',
-                        headers: {{'Content-Type': 'application/json'}},
-                        body: JSON.stringify({{hoster_id: hosterId}})
-                    }});
-                    if (response.ok) {{
-                        location.reload();
-                    }} else {{
-                        alert('Error: ' + (await response.text()));
-                    }}
-                }} catch (e) {{
-                    alert('Error: ' + e.message);
-                }}
-            }}
-            
-            async function blockAll() {{
-                if (!confirm('Block all hosters?')) return;
-                try {{
-                    const response = await kuasarrApiFetch('/api/hosters/block-all', {{method: 'POST'}});
-                    if (response.ok) location.reload();
-                }} catch (e) {{
-                    alert('Error: ' + e.message);
-                }}
-            }}
-            
-            async function unblockAll() {{
-                if (!confirm('Unblock all hosters?')) return;
-                try {{
-                    const response = await kuasarrApiFetch('/api/hosters/unblock-all', {{method: 'POST'}});
-                    if (response.ok) location.reload();
-                }} catch (e) {{
-                    alert('Error: ' + e.message);
-                }}
-            }}
-        </script>
-        """
-        return render_centered_html(html)
 
     @app.get('/api/hosters')
     @require_api_key
@@ -187,17 +21,21 @@ def setup_hosters_routes(app):
         """Get all hosters with their block status."""
         response.content_type = 'application/json'
         blocked = _get_blocked_list()
-        
+
         result = []
         for hoster_id, hoster_info in SUPPORTED_HOSTERS.items():
+            is_blocked = hoster_id in blocked
             result.append({
                 "id": hoster_id,
                 "name": hoster_info["name"],
-                "domain": hoster_info["domain"],
-                "blocked": hoster_id in blocked
+                "url": hoster_info["domain"],
+                "blocked": is_blocked,
+                "enabled": not is_blocked,
+                "priority": 0,
+                "status": "unknown",
             })
-        
-        return json.dumps(sorted(result, key=lambda x: x["name"]))
+
+        return json.dumps({"data": sorted(result, key=lambda x: x["name"])})
 
     @app.post('/api/hosters/block')
     @require_api_key

--- a/kuasarr/webui/src/pages/Notifications.tsx
+++ b/kuasarr/webui/src/pages/Notifications.tsx
@@ -26,25 +26,21 @@ import { Spinner } from '../components/ui/Spinner';
 import { Modal } from '../components/ui/Modal';
 import { Toggle } from '../components/ui/Toggle';
 import { useUIStore } from '../stores/uiStore';
-import type { NotificationProvider, NotificationConfig, NotificationEvent, NotificationSettings } from '../types';
+import {
+  getNotificationSettings,
+  saveNotificationSettings,
+  testNotification as testNotificationApi,
+} from '../lib/api';
+import type { NotificationProvider, NotificationConfig, NotificationEvent } from '../types';
 
-// Mock API functions - these would be implemented in lib/api.ts
-const getNotificationSettings = async (): Promise<NotificationSettings> => {
-  // This is a mock - replace with actual API call
-  return {
-    global_enabled: true,
-    configs: [],
-  };
-};
-
-const saveNotificationSettings = async (settings: NotificationSettings): Promise<void> => {
-  // This is a mock - replace with actual API call
-  console.log('Saving settings:', settings);
-};
-
-const testNotification = async (provider: NotificationProvider, settings: Record<string, string | number | boolean>): Promise<void> => {
-  // This is a mock - replace with actual API call
-  console.log('Testing notification:', provider, settings);
+const testNotification = async (
+  provider: NotificationProvider,
+  settings: Record<string, string | number | boolean>
+): Promise<void> => {
+  const result = await testNotificationApi({ provider, settings });
+  if (!result.success) {
+    throw new Error(result.message || 'Test failed');
+  }
 };
 
 const providerIcons: Record<NotificationProvider, React.ElementType> = {


### PR DESCRIPTION
## Summary

Fixes several issues in the new React UI where sections showed no content or failed to load.

### Root causes & fixes

**1. API key not sent in frontend requests**
`fetchApi()` in `api.ts` never included `window.KUASARR_API_KEY` (injected by `spa.py`) as `X-API-Key` header — all `/api/*` calls returned 401. Also fixes header merging so caller-supplied headers are properly merged.

**2. `workbox-*.js` served with wrong MIME type (`text/html`)**
The SPA catch-all returned `index.html` for root-level dist files without an explicit route (including the hashed `workbox-*.js` bundle). The service worker then failed with `importScripts()` rejecting the wrong MIME type. The catch-all now serves any flat file found in the webui dist root with the correct MIME type before falling through to the SPA — handles current and future hashed build artifacts automatically.

**3. API response formats mismatched with React UI expectations**
All backend endpoints (except JDownloader) returned wrong JSON shapes:
- `/api/categories` — returned `{"success": true, "categories": [...]}` with `download_path`/`file_patterns` fields; now returns `{"data": [...]}` with `pattern`/`priority`/`enabled`. Old-format records are migrated on read.
- `/api/hosters` — returned a plain array with `domain`; now returns `{"data": [...]}` with `url`, `enabled`, `priority`, `status`.
- `/api/statistics` — endpoint didn't exist; Dashboard threw on every load. Added stub returning zeros + real uptime.
- Legacy HTML routes for `/categories` and `/hosters` removed — requests now fall through to the SPA catch-all (also fixes the Ctrl+Shift+R → legacy UI regression).

**4. Notifications page used inline mock functions**
`Notifications.tsx` had local no-op stubs instead of importing from `lib/api.ts`. Replaced with real API calls + a thin adapter for `testNotification`.

## Test plan

- [ ] All `/api/*` calls return 200 (no 401s in browser console)
- [ ] Service worker registers without MIME-type errors
- [ ] Categories page shows data / create+edit+delete works
- [ ] Hosters page lists all hosters with correct block status
- [ ] Dashboard renders with uptime and zero-state stats
- [ ] Notifications page loads settings from backend (not hardcoded empty)
- [ ] Hard reload (Ctrl+Shift+R) on `/categories`, `/hosters` serves React SPA, not legacy HTML

https://claude.ai/code/session_01UsVXmbPXVrrPYRmjKtzeMG