### PR TITLE
fix: poll JD status on app load; fix password autocomplete

### DIFF
--- a/kuasarr/webui/src/App.tsx
+++ b/kuasarr/webui/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
 import { Dashboard } from './pages/Dashboard';
 import { Packages } from './pages/Packages';
 import Search from './pages/Search';
@@ -9,6 +10,8 @@ import Settings from './pages/Settings';
 import Statistics from './pages/Statistics';
 import Notifications from './pages/Notifications';
 import NotFound from './pages/NotFound';
+import { getJDownloaderStatus } from './lib/api';
+import { useUIStore } from './stores/uiStore';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -20,9 +23,27 @@ const queryClient = new QueryClient({
   },
 });
 
+function JdStatusPoller() {
+  const { setJdConnected, setJdStatus } = useUIStore();
+  const { data } = useQuery({
+    queryKey: ['jdownloader-status-global'],
+    queryFn: getJDownloaderStatus,
+    refetchInterval: 30000,
+    staleTime: 0,
+  });
+  useEffect(() => {
+    if (data !== undefined) {
+      setJdStatus(data);
+      setJdConnected(data.connected);
+    }
+  }, [data, setJdStatus, setJdConnected]);
+  return null;
+}
+
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
+      <JdStatusPoller />
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Dashboard />} />

--- a/kuasarr/webui/src/pages/Settings.tsx
+++ b/kuasarr/webui/src/pages/Settings.tsx
@@ -310,6 +310,7 @@ export default function SettingsPage() {
                         value={formData.password}
                         onChange={(e) => setFormData({ ...formData, password: e.target.value })}
                         error={formErrors.password}
+                        autoComplete="current-password"
                         leftIcon={<Lock className="h-4 w-4" />}
                         rightIcon={
                           <button


### PR DESCRIPTION
## Summary

- **JDownloader connected badge always wrong on first load** — `jdConnected` in the Zustand store defaulted to `false` and was only updated when the Settings page mounted. Added `JdStatusPoller` (a null-rendering component inside `QueryClientProvider` in `App.tsx`) that fetches `/api/jdownloader/status` on mount and polls every 30 s, so the connected badge is correct on every page immediately after load.
- **Password field autocomplete warning** — added `autoComplete="current-password"` to the JDownloader password input in `Settings.tsx` to suppress browser console warnings about missing autocomplete hints.

## Test plan

- [ ] Hard reload on Dashboard — JDownloader badge shows correct connected state without visiting Settings first
- [ ] Wait 30 s — badge updates automatically if connection state changes
- [ ] No browser console warnings about password field autocomplete

https://claude.ai/code/session_01UsVXmbPXVrrPYRmjKtzeMG