### PR TITLE
fix(webui): fix MobileNav scrolling with content on iOS Safari

### DIFF
--- a/kuasarr/webui/index.html
+++ b/kuasarr/webui/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>webui</title>
   </head>
   <body>

--- a/kuasarr/webui/src/components/layout/Layout.tsx
+++ b/kuasarr/webui/src/components/layout/Layout.tsx
@@ -10,19 +10,22 @@ interface LayoutProps {
 
 export function Layout({ children, jdConnected = false }: LayoutProps) {
   return (
-    <div className="min-h-screen bg-bg-primary">
+    <div className="h-[100dvh] flex flex-col bg-bg-primary overflow-hidden">
       {/* Top Navigation */}
       <Navbar jdConnected={jdConnected} />
 
-      {/* Left Sidebar (Desktop) */}
-      <Sidebar />
+      {/* Middle: Sidebar + Content */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Left Sidebar (Desktop) */}
+        <Sidebar />
 
-      {/* Main Content Area */}
-      <main className="pt-16 lg:pl-64 pb-16 lg:pb-0 min-h-screen">
-        <div className="p-4 sm:p-6 lg:p-8 max-w-7xl mx-auto">
-          {children}
-        </div>
-      </main>
+        {/* Main Content Area */}
+        <main className="flex-1 overflow-y-auto">
+          <div className="p-4 sm:p-6 lg:p-8 max-w-7xl mx-auto">
+            {children}
+          </div>
+        </main>
+      </div>
 
       {/* Bottom Navigation (Mobile) */}
       <MobileNav />

--- a/kuasarr/webui/src/components/layout/MobileNav.tsx
+++ b/kuasarr/webui/src/components/layout/MobileNav.tsx
@@ -25,7 +25,7 @@ export function MobileNav() {
   const location = useLocation()
 
   return (
-    <nav className="lg:hidden fixed bottom-0 left-0 right-0 z-50 bg-bg-secondary/95 backdrop-blur-lg border-t border-bg-tertiary safe-area-pb">
+    <nav className="lg:hidden flex-shrink-0 z-50 bg-bg-secondary/95 backdrop-blur-lg border-t border-bg-tertiary safe-area-pb">
       <div className="flex items-center justify-around h-16">
         {mobileNavItems.map((item) => {
           const Icon = item.icon

--- a/kuasarr/webui/src/components/layout/Navbar.tsx
+++ b/kuasarr/webui/src/components/layout/Navbar.tsx
@@ -31,7 +31,7 @@ export function Navbar({ jdConnected = false }: NavbarProps) {
   const { isMobileMenuOpen, toggleMobileMenu, closeMobileMenu } = useUIStore()
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 h-16">
+    <header className="flex-shrink-0 z-50 h-16">
       <nav className="h-full glass border-b border-bg-tertiary/50">
         <div className="h-full px-4 sm:px-6 lg:px-8 flex items-center justify-between">
           {/* Logo */}

--- a/kuasarr/webui/src/components/layout/Navbar.tsx
+++ b/kuasarr/webui/src/components/layout/Navbar.tsx
@@ -31,8 +31,8 @@ export function Navbar({ jdConnected = false }: NavbarProps) {
   const { isMobileMenuOpen, toggleMobileMenu, closeMobileMenu } = useUIStore()
 
   return (
-    <header className="flex-shrink-0 z-50 h-16">
-      <nav className="h-full glass border-b border-bg-tertiary/50">
+    <header className="flex-shrink-0 z-50 flex flex-col safe-area-pt">
+      <nav className="h-16 glass border-b border-bg-tertiary/50">
         <div className="h-full px-4 sm:px-6 lg:px-8 flex items-center justify-between">
           {/* Logo */}
           <Link

--- a/kuasarr/webui/src/components/layout/Sidebar.tsx
+++ b/kuasarr/webui/src/components/layout/Sidebar.tsx
@@ -103,7 +103,7 @@ export function Sidebar() {
   return (
     <>
       {/* Desktop Sidebar */}
-      <aside className="hidden lg:flex flex-col w-64 h-screen fixed left-0 top-16 bg-bg-secondary border-r border-bg-tertiary">
+      <aside className="hidden lg:flex flex-col w-64 flex-shrink-0 bg-bg-secondary border-r border-bg-tertiary overflow-y-auto">
         {sidebarContent}
       </aside>
 

--- a/kuasarr/webui/src/index.css
+++ b/kuasarr/webui/src/index.css
@@ -91,3 +91,9 @@
     padding-bottom: env(safe-area-inset-bottom);
   }
 }
+
+@supports (padding-top: env(safe-area-inset-top)) {
+  .safe-area-pt {
+    padding-top: env(safe-area-inset-top);
+  }
+}

--- a/kuasarr/webui/src/index.css
+++ b/kuasarr/webui/src/index.css
@@ -27,10 +27,13 @@
 
   html {
     @apply scroll-smooth;
+    height: 100%;
   }
 
   body {
-    @apply bg-bg-primary text-text-primary font-sans antialiased min-h-screen;
+    @apply bg-bg-primary text-text-primary font-sans antialiased;
+    height: 100%;
+    overflow: hidden;
   }
 
   h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
Replace position:fixed layout with a flex-column container model so
the MobileNav and Navbar are normal flex children instead of fixed
elements. On iOS Safari, position:fixed elements flicker and scroll
with content during momentum scrolling due to dynamic viewport changes.

- Layout: h-[100dvh] flex-column wrapper, main content scrolls via
  overflow-y:auto, no more pt-16/pb-16/lg:pl-64 offsets needed
- Navbar: removed fixed top-0, now a natural flex-shrink-0 item
- Sidebar (desktop): removed fixed left-0 top-16, now flex-shrink-0
  in the middle row alongside main
- MobileNav: removed fixed bottom-0, now a flex-shrink-0 item at the
  bottom of the column (lg:hidden still applies)
- index.html: added viewport-fit=cover for correct safe-area on iOS
- index.css: body/html use height:100%+overflow:hidden so only main
  scrolls, not the page

https://claude.ai/code/session_01TAfNdp7EGc8HYMVu6b2fH2