### PR TITLE
chore(claude): add Claude Code automations (skills, subagents, hooks)

### DIFF
--- a/.claude/agents/newznab-contract-reviewer.md
+++ b/.claude/agents/newznab-contract-reviewer.md
@@ -1,0 +1,22 @@
+---
+name: newznab-contract-reviewer
+description: Verifies Kuasarr's Newznab indexer and SABnzbd download-client API contract is preserved by a change. Use when kuasarr/api/ (especially arr/, categories/, packages/) changes, or when search/download source output shapes change. Reports only — does not edit.
+tools: Read, Grep, Glob, Bash
+---
+
+You verify that a change does NOT break the API contract that Radarr/Sonarr/LazyLibrarian depend on. Kuasarr exposes ONE base (`/api`) and distinguishes by params: `t=` (Newznab indexer: search/caps/tvsearch/movie) vs `mode=` (SABnzbd client: version/queue/addurl/history).
+
+## What must stay stable
+
+1. **Newznab response shape** (`t=`): RSS `<channel>`/`<item>` with `<title>`, `<link>`, `<size>`, `<pubDate>`, `<category>`, and `<attr name="...">` (imdbid, tvdbid, rid, season, episode, etc.); valid `caps` output. Category ids must match `kuasarr/categories/`.
+2. **SABnzbd response shape** (`mode=`): the fields Radarr/Sonarr's SABnzbd client expects (queue/history/addurl/version) — field names and JSON/XML structure intact.
+3. **Routing & auth**: the `t=` vs `mode=` dispatch logic; API endpoints stay API-key-only (never WebUI-basic-auth protected), WebUI auth stays separate.
+4. **Source output**: search sources must return Newznab-shaped items; download sources must return resolvable links — don't silently rename/remove item fields.
+
+## How to verify
+
+- Diff `kuasarr/api/` and any source-output shaping; compare against existing endpoint handlers and a sample response.
+- For each risk: `file:line`, what breaks, which *arr integration is affected, and a minimal fix.
+- Preserve the contract: prefer additive changes over renaming/removing fields.
+
+Report only — do not edit files.

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,25 @@
+---
+name: security-reviewer
+description: Adversarial security review of a diff/change. Use proactively when changes touch CAPTCHA solving, link decryption (pycryptodomex), FlareSolverr/anti-bot, API keys, sessions, or any file under kuasarr/api/ or kuasarr/providers/. Runs in parallel isolation. Reports only — does not edit.
+tools: Read, Grep, Glob, Bash
+---
+
+You are a security reviewer for the Kuasarr project — a Python bridge that does CAPTCHA solving (DeathByCaptcha / 2Captcha), link decryption (`pycryptodomex`), anti-bot circumvention (FlareSolverr), JS eval of obfuscated links (`dukpy`), and handles third-party API credentials.
+
+## Focus (flag anything that matches)
+
+1. **Credential / hostname leakage** — hardcoded API keys, tokens, passwords, or source hostnames/URLs in non-gitignored files. Per `AGENTS.md` these must NEVER be committed; real hostnames belong in `kuasarr.ini`/env only. In code only the `initials` id is allowed.
+2. **Unsafe HTTP** — `requests`/`urllib3` calls with `verify=False`, `ssl._create_unverified_context`, blind `urljoin` of untrusted input, SSRF surface, missing timeouts.
+3. **Decryption / code execution** — misuse of `pycryptodomex`, `eval`/`exec`/`dukpy` on untrusted/scraped input, regex/ReDoS over large scraped HTML, unsafe deserialization.
+4. **Secrets at rest** — API keys or tokens written to logs, cached to disk unencrypted, or echoed into error/exception messages.
+5. **Auth/session** — credential handling in `kuasarr/providers/sessions/` and the `[Captcha]` config; ensure DBC/2Captcha tokens stay out of source.
+
+## How to review
+
+- Read the diff (`git --no-pager diff` plus `--cached` if needed) and surrounding context.
+- For each finding: `file:line`, severity (critical/high/medium/low), why it is exploitable, and a concrete fix.
+- Default to flagging anything uncertain rather than silently passing.
+
+## Out of scope
+
+Style, performance, test coverage, doc wording — only security-relevant issues. Do NOT modify files; report only.

--- a/.claude/hooks/guard_commit.sh
+++ b/.claude/hooks/guard_commit.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# PreToolUse guard for `git commit` — blocks accidental commits of secrets / source hostnames.
+# Called by Claude Code PreToolUse hook (matcher: Bash). Reads the tool-call JSON from stdin.
+# Exit 2 = block the tool call in Claude Code; 0 = allow.
+#
+# Project rule (AGENTS.md): API keys, kuasarr.ini, and source hostnames must NEVER be committed.
+# The known-hostname list is optional and gitignored (local only): .claude/.secrets/known_hostnames.txt
+set -uo pipefail
+
+input="$(cat)"
+cmd="$(printf '%s' "$input" | python3 -c 'import sys,json
+try:
+    d=json.load(sys.stdin); print(d.get("tool_input",{}).get("command",""))
+except Exception:
+    print("")' 2>/dev/null)"
+
+# Only act on commits
+case "$cmd" in
+  *git\ commit*|*"git commit"*) : ;;
+  *) exit 0 ;;
+esac
+
+# 1) Block staging anything under .claude/.secrets/ (API keys)
+if git diff --cached --name-only 2>/dev/null | grep -qE '^\.claude/\.secrets(/|$)'; then
+  echo "BLOCKED (commit): staging files under .claude/.secrets/ is forbidden (API keys)." >&2
+  exit 2
+fi
+
+# 2) Block high-signal secret patterns in added lines
+if git diff --cached -U0 2>/dev/null | grep -E '^\+' | grep -qiE '(api[_-]?key|apikey|secret|token|password|passwd|pwd|authtoken)[[:space:]]*[=:][[:space:]]*["'"'"'][A-Za-z0-9._\-]{16,}'; then
+  echo "BLOCKED (commit): staged diff contains a likely secret (key/token/password)." >&2
+  echo "Move the value to ENV/kuasarr.ini — never commit it." >&2
+  exit 2
+fi
+
+# 3) Optional: known source hostnames (gitignored, local only)
+known=".claude/.secrets/known_hostnames.txt"
+if [ -f "$known" ]; then
+  while IFS= read -r host || [ -n "$host" ]; do
+    case "$host" in ''|'#'*) continue ;; esac
+    # host is used as a fixed string in the grep pattern
+    if git diff --cached 2>/dev/null | grep -qF -- "+${host}"; then
+      echo "BLOCKED (commit): staged diff references known source hostname '${host}'." >&2
+      echo "Per AGENTS.md hostnames must never be committed." >&2
+      exit 2
+    fi
+  done < "$known"
+fi
+
+exit 0

--- a/.claude/hooks/guard_version.sh
+++ b/.claude/hooks/guard_version.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# PreToolUse guard for Edit/Write/MultiEdit — blocks direct edits to version.json.
+# The version source of truth is Hier_Version_Ändern.txt; CI propagates to version.json.
+# Exit 2 = block the tool call in Claude Code; 0 = allow.
+set -uo pipefail
+
+input="$(cat)"
+path="$(printf '%s' "$input" | python3 -c 'import sys,json
+try:
+    d=json.load(sys.stdin)
+    ti=d.get("tool_input",{})
+    p=ti.get("file_path") or ti.get("notebook_path") or ""
+    print(p if isinstance(p,str) else "")
+except Exception:
+    print("")' 2>/dev/null)"
+
+case "$path" in
+  version.json|*/version.json)
+    echo "BLOCKED: version.json must not be edited directly." >&2
+    echo "Change the version in Hier_Version_Ändern.txt — CI propagates it." >&2
+    exit 2
+    ;;
+esac
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,26 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard_commit.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard_version.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/skills/add-source/SKILL.md
+++ b/.claude/skills/add-source/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: add-source
+description: Scaffold a new DDL source for Kuasarr following the existing NK/DW/SJ pattern — a search source (kuasarr/search/sources/XX.py) plus a download source (kuasarr/downloads/sources/XX.py), each exposing a `Source` class. Sources auto-register via pkgutil discovery. Use when adding support for a new source.
+---
+
+# Add a new Kuasarr source
+
+Use this skill to add a new DDL source (two-letter uppercase identifier, e.g. `NK`, `DW`, `SJ`) following the established pattern. **Sources auto-register** — there is no manual registry to edit.
+
+## CRITICAL — never commit hostnames or URLs
+
+Per `AGENTS.md`, source hostnames/URLs must NEVER appear in any file that is not gitignored. Keep real hostnames in the runtime config (`kuasarr.ini`) / env only. In code, reference the source by its `initials` (e.g. `"nk"`) and read the configured hostname from settings at runtime — copy exactly how existing sources do it (see `hostname = "nk"` style identifiers, which are just the id, not the real URL).
+
+## What a source is
+
+A source is a pair of modules, auto-discovered by filename via `pkgutil.iter_modules` in `search/sources/__init__.py` and `downloads/sources/__init__.py`:
+
+| Layer | Path | Base class | Purpose |
+|-------|------|------------|---------|
+| Search | `kuasarr/search/sources/XX.py` | `kuasarr.search.base.AbstractSearchSource` | Search listings → RSS items for the Newznab response |
+| Download | `kuasarr/downloads/sources/XX.py` | `kuasarr.downloads.base.AbstractDownloadSource` | Resolve a release URL → decrypted download links |
+
+`XX` = lowercase module name (e.g. `nk.py`). Both classes MUST be named `Source` and expose an `initials` attribute (the 2-letter id). Modules starting with `_` are skipped by discovery.
+
+## Steps
+
+1. **Read the base contracts** — `kuasarr/search/base.py` and `kuasarr/downloads/base.py` to learn the required methods/attributes (`initials`, search/resolve methods, return shapes).
+2. **Pick a template** — copy the closest existing source:
+   - `nk.py` — simple HTML scrape + mirrors (`supported_mirrors`).
+   - `sj.py` — credential + reCAPTCHA session under `kuasarr/providers/sessions/`.
+3. **Create the search source** at `kuasarr/search/sources/<initials>.py`:
+   - `class Source(AbstractSearchSource)` with `initials = "xx"`.
+   - Implement search/listing → Newznab/RSS-shaped items.
+   - Reuse helpers: `kuasarr.providers.imdb_metadata.get_localized_title`, `kuasarr.providers.log.{info,debug}`, `BeautifulSoup`, `requests`.
+4. **Create the download source** at `kuasarr/downloads/sources/<initials>.py`:
+   - `class Source(AbstractDownloadSource)` with matching `initials`.
+   - Resolve release page → decrypt captcha-protected links (see `kuasarr/downloads/linkcrypters/`, e.g. `filecrypt.py`, `keeplinks.py`).
+   - If login/captcha is needed, add a session helper under `kuasarr/providers/sessions/<initials>.py` (mirror `sj.py`).
+5. **Categorization** — check `kuasarr/categories/` to map releases to Newznab categories; add a mapping if missing.
+6. **Verify** — `python3 -m py_compile` both files, then run `python3 -m pytest`. Confirm the source is discovered (its `initials` appears in `get_sources()` keys).
+7. **Docs** — per Documentation-First (`AGENTS.md`), update `docs/` to describe the new source (behavior/workflow). Do NOT put the hostname in docs.
+
+## Don't
+
+- No hardcoded hostnames/URLs — config only.
+- Don't edit the `__init__.py` registries (auto-discovered).
+- Keep the commit delta minimal — only the two modules (+ session/categories files if needed).
+- This is NOT a torrent/usenet client — never add NZB/torrent/magnet handling.

--- a/.claude/skills/pre-submit/SKILL.md
+++ b/.claude/skills/pre-submit/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: pre-submit
+description: Run Kuasarr's documented pre-PR checks before opening a pull request — Python syntax check, pytest, WebUI build, hostname/secret leak scan, docs-sync check, and API-contract check. Use before submitting work. Invoked via /pre-submit.
+disable-model-invocation: true
+---
+
+# Pre-submit checks for Kuasarr
+
+Run these before opening a PR (per `AGENTS.md`: "run the documented checks before submitting work"). Report a Go / No-Go per check. **Do NOT auto-commit or push.**
+
+## Checks
+
+1. **Python syntax** — `python3 -m py_compile` on every changed `.py` file (find them with `git --no-pager diff --name-only`).
+2. **Tests** — `python3 -m pytest -q`. (Note: `tests/` is gitignored locally, but pytest runs them when present in the working tree.)
+3. **WebUI build** — only if `kuasarr/webui/` changed: `cd kuasarr/webui && npm run build` (runs `tsc -b && vite build`). Must succeed with no TS errors — the built `dist/` is what Python serves.
+4. **Hostname / secret leak scan** — scan staged/working changes for source hostnames and secrets:
+   - `git --no-pager diff` must not reference `.claude/.secrets/`, real source URLs, or API keys.
+   - If `.claude/.secrets/known_hostnames.txt` exists, grep the diff against each listed hostname.
+5. **Docs sync** — per Documentation-First: if behavior/workflow/conventions changed, the matching `docs/` file must be updated. Flag missing doc updates.
+6. **API contract** — if `kuasarr/api/` changed, confirm Newznab (`t=`) and SABnzbd (`mode=`) response shapes are unchanged (hand off to the `newznab-contract-reviewer` subagent for a deep check).
+7. **Version discipline** — confirm `version.json` was NOT hand-edited; the version source of truth is `Hier_Version_Ändern.txt`.
+
+## Output
+
+A short report: one line per check with ✅/❌ and the exact command to fix any failure. End with an overall Go / No-Go.


### PR DESCRIPTION
## What

Adds Claude Code automations for the Kuasarr repo.

### Skills (`.claude/skills/`)
- **`add-source`** — scaffolds a new DDL source following the NK/DW/SJ pattern. Sources auto-register via `pkgutil` discovery, so it reads the base classes in `kuasarr/{search,downloads}/base.py` and documents the required `class Source` + `initials` contract. Enforces the `AGENTS.md` rule that hostnames/URLs are never committed.
- **`pre-submit`** (`/pre-submit`) — runs the documented pre-PR checks: `py_compile`, `pytest`, WebUI `npm run build`, hostname/secret leak scan, docs-sync, and API-contract sanity.

### Subagents (`.claude/agents/`)
- **`security-reviewer`** — adversarial review for credential/hostname leakage, unsafe HTTP (`verify=False`), and `eval`/`dukpy`/`pycryptodomex` misuse on untrusted input.
- **`newznab-contract-reviewer`** — verifies Newznab (`t=`) and SABnzbd (`mode=`) response shapes stay intact when `kuasarr/api/` changes.

### Hooks (`.claude/hooks/`, wired into `.claude/settings.json` `PreToolUse`)
- **`guard_commit.sh`** — blocks `git commit` if staged changes contain API keys/tokens, files under `.claude/.secrets/`, or any hostname listed in the optional gitignored `.claude/.secrets/known_hostnames.txt`.
- **`guard_version.sh`** — blocks direct edits to `version.json` (source of truth is `Hier_Version_Ändern.txt`).

## Verification
- `bash -n` on both hook scripts: OK
- `settings.json` JSON validity: OK
- Smoke tests: `version.json` edit → blocked (exit 2); normal file → allowed (exit 0); commit with no secrets → allowed (exit 0).
- The commit hook passed its first live run by allowing this very commit.

## Notes
- Scope is limited to `.claude/`. Unrelated `imdb_metadata.py` work is **not** included.
- `.claude/skills/arr/` (existing local *arr diagnostics, contains LAN IPs) is intentionally left untracked — happy to add separately if desired.
- No secrets, hostnames, or `kuasarr.ini` are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)